### PR TITLE
Add local methylation analysis environment bootstrap.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ c_tools/utils/configure
 c_tools/tmp_root
 .idea
 *.iml
+.venv
+__pycache__
+*.ipynb_checkpoints

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+numpy
+pandas
+matplotlib
+seaborn
+scipy
+pysam
+pyfaidx
+jupyterlab


### PR DESCRIPTION
Include Python analysis dependencies and ignore virtualenv/notebook cache artifacts so repo setup is reproducible without committing local environment files.